### PR TITLE
Update Snyk to v1.1168.0

### DIFF
--- a/snyk/snyk.nuspec
+++ b/snyk/snyk.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>snyk</id>
-    <version>v1.1168.0</version>
+    <version>1.1168.0</version>
     <title>Snyk</title>
     <authors>Snyk</authors>
     <owners>ducksecops</owners>

--- a/snyk/snyk.nuspec
+++ b/snyk/snyk.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>snyk</id>
-    <version>1.945.0</version>
+    <version>v1.1168.0</version>
     <title>Snyk</title>
     <authors>Snyk</authors>
     <owners>ducksecops</owners>

--- a/snyk/tools/chocolateyinstall.ps1
+++ b/snyk/tools/chocolateyinstall.ps1
@@ -5,8 +5,8 @@ $fileLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $packageArgs = @{
   PackageName  = $env:ChocolateyPackageName
   FileFullPath = "$fileLocation\snyk.exe"
-  Url          = 'https://github.com/snyk/cli/releases/download/v1.945.0/snyk-win.exe'
-  Checksum     = '446cab140b81d915cb766b72e367e83fa7fbf01c5e230eea5d2c73b0345890ba'
+  Url          = 'https://github.com/snyk/cli/releases/download/v1.1168.0/snyk-win.exe'
+  Checksum     = '93cb099ce604ee814b80f1b31ae4e0769873e9ea8672adcd7657e378199045d6'
   ChecksumType = 'sha256'
 }
 


### PR DESCRIPTION
The version for the Snyk tool is reporting a vulnerability due to being an old version.

This PR updates Snyk tool to latest

Tested installing it locally after creating nupkg with `choco pack .\snyk.nuspec`

```bash
C:\Workspace\ducksecops-chocolatey\snyk [main ≡ +1 ~0 -0 !]> choco install Snyk -s .\snyk.1.1168.0.nupkg
The use of .nupkg or .nuspec in for package name or source is known to cause issues. Please use the package id from the nuspec `<id />` with `-s .` (for local folder where nupkg is found).
Chocolatey v1.4.0
Installing the following packages:
Snyk
By installing, you accept licenses for the packages.

snyk v1.1168.0
snyk package files install completed. Performing other installation steps.
The package snyk wants to run 'chocolateyinstall.ps1'.
Note: If you don't run this script, the installation will fail.
Note: To confirm automatically next time, use '-y' or consider:
choco feature enable -n allowGlobalConfirmation
Do you want to run the script?([Y]es/[A]ll - yes to all/[N]o/[P]rint): Y

Downloading snyk
  from 'https://github.com/snyk/cli/releases/download/v1.1168.0/snyk-win.exe'
Progress: 100% - Completed download of C:\ProgramData\chocolatey\lib\snyk\tools\snyk.exe (94.97 MB).
Download of snyk.exe (94.97 MB) completed.
Hashes match.
C:\ProgramData\chocolatey\lib\snyk\tools\snyk.exe
 ShimGen has successfully created a shim for snyk.exe
 The install of snyk was successful.
  Software install location not explicitly set, it could be in package or
  default install location of installer.

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Enjoy using Chocolatey? Explore more amazing features to take your
experience to the next level at
 https://chocolatey.org/compare
```

Abd check


```bash
C:\Workspace\ducksecops-chocolatey\snyk [main ≡ +1 ~0 -0 !]> snyk --version
1.1168.0
```
